### PR TITLE
Switched from jessie-slim to jessie, because installation of JDK fail…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-# Copyright (c) General Electric Company, 2017.  All rights reserved.
-FROM debian:jessie-slim
+# Copyright (c) General Electric Company, 2019.  All rights reserved.
+FROM debian:jessie
 
 # install dependencies
 RUN buildDeps='python-pip' \
     && set -x \
     && apt-get -y update && apt-get install -y $buildDeps --no-install-recommends \
     && pip install --upgrade pip && hash -r \
-    && pip install flask pika boto3 requests junit-xml pytest-cov \
+    && pip install flask pika==0.9.14 boto3 requests==2.19 junit-xml pytest-cov \
     && pip install --upgrade setuptools
 
 # install SDK

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 # Copyright (c) General Electric Company, 2019.  All rights reserved.
-FROM debian:jessie
+#FROM debian:jessie
+FROM debian:stretch
 
 # install dependencies
 RUN buildDeps='python-pip' \
     && set -x \
     && apt-get -y update && apt-get install -y $buildDeps --no-install-recommends \
     && pip install --upgrade pip && hash -r \
-    && pip install flask pika==0.9.14 boto3 requests==2.19 junit-xml pytest-cov \
-    && pip install --upgrade setuptools
+    && pip install --upgrade setuptools \
+    && pip install flask pika==0.9.14 boto3 requests==2.19 junit-xml pytest-cov
 
 # install SDK
 ADD rt106GenericAdaptorSQS.py rt106GenericAdaptorAMQP.py rt106GenericAdaptorREST.py rt106SpecificAdaptorCode.py rt106SpecificAdaptorDefinitions.json entrypoint.sh testGenericAdaptorAPIs.py testGenericAdaptorAMQP.py /rt106/

--- a/algrebuild.sh
+++ b/algrebuild.sh
@@ -2,16 +2,12 @@
 # Copyright (c) General Electric Company, 2017.  All rights reserved.
 
 echo ""
-echo "Removing algorithm container."
-docker rm rt106_algorithmtemplate_1
-
-echo ""
 echo "Removing algorithm image."
-docker rmi rt106/rt106-algorithm-sdk
+docker rmi thriveitcr/rt106-algorithm-sdk
 
 echo ""
 echo "Building algorithm image."
-docker build -t rt106/rt106-algorithm-sdk --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy .
+docker build -t thriveitcr/rt106-algorithm-sdk --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy .
 
 echo ""
 docker images


### PR DESCRIPTION
…s in jessie-slim.  Set explicit version numbers of some Python packages for backwards compatibility.